### PR TITLE
[SDAO-17] Add Multisig contract

### DIFF
--- a/contracts/Consumer.sol
+++ b/contracts/Consumer.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.0;
+
+contract Consumer {
+    bytes11 public lastFixedBytes;
+    bytes public lastVarBytes;
+    uint104 public lastUint;
+    string public lastString;
+    uint public lastDataSize;
+
+    function updateData(
+        bytes11 fb,
+        bytes memory vb,
+        uint104 ui,
+        string memory str
+    ) public {
+        lastFixedBytes = fb;
+        lastVarBytes = vb;
+        lastUint = ui;
+        lastString = str;
+        lastDataSize = msg.data.length;
+    }
+
+}

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity >=0.4.21 <0.6.0;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/contracts/Multisig.sol
+++ b/contracts/Multisig.sol
@@ -1,0 +1,109 @@
+pragma solidity ^0.5.0;
+
+// This feature is considered mature enough to not cause any
+// security issues, so the possible warning should be ignored.
+// As per solidity developers, "The main reason it is marked
+// experimental is because it causes higher gas usage."
+// See: https://github.com/ethereum/solidity/issues/5397
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/cryptography/ECDSA.sol";
+
+contract Multisig {
+    uint public nonce;
+    address[] public owners;
+    mapping(address => bool) public isOwner;
+    uint public threshold;
+
+    constructor(address[] memory _owners, uint _threshold) public {
+        updateOwners(_owners);
+        threshold = _threshold;
+        nonce = 0;
+    }
+
+    function execute(
+        address destination,
+        uint256 value,
+        bytes memory data,
+        bytes[] memory signatures
+    )
+        public
+    {
+        // Note that `data` is the only variable-length parameter, so
+        // we can safely use `encodePacked` here. If this wasn't the case,
+        // since length is not encoded, it would be possible to craft
+        // the parameters in such a way that they would mix up, and
+        // the whole setting would become insecure.
+        bytes memory toSign = abi.encodePacked(
+            uint8(0x19), uint8(0x00), address(this),
+            destination, value, data, nonce
+        );
+        checkSignatures(toSign, signatures);
+        nonce = nonce + 1;
+
+        // Since Istanbul update, the best practice has changed [1],
+        // now it's recommended to use call.value instead of transfer.
+        // Thus, the security/no-call-value warning is just wrong.
+        // For more information, see [2].
+        //
+        // [1]: https://diligence.consensys.net/blog/2019/09/stop-using-soliditys-transfer-now
+        // [2]: https://github.com/ConsenSys/smart-contract-best-practices/pull/226/files
+
+        /* solium-disable-next-line security/no-call-value */
+        (bool txSuccessful, ) = destination.call.value(value)(data);
+        require(txSuccessful, "Failed to call the requested contract");
+    }
+
+    function rotateKeys(
+        address[] memory newOwners,
+        uint newThreshold,
+        bytes[] memory signatures
+    )
+        public
+    {
+        // Note that `newOwners` is the only variable-length parameter, so
+        // we can safely use `encodePacked` here. If this wasn't the case,
+        // since length is not encoded, it would be possible to craft
+        // the parameters in such a way that they would mix up, and
+        // the whole setting would become insecure.
+        bytes memory toSign = abi.encodePacked(
+            byte(0x19), byte(0), address(this),
+            newOwners, newThreshold, nonce
+        );
+        checkSignatures(toSign, signatures);
+        nonce = nonce + 1;
+        updateOwners(newOwners);
+        threshold = newThreshold;
+    }
+
+    function checkSignatures(bytes memory dataToSign, bytes[] memory signatures)
+        internal
+        view
+    {
+        // We fail on duplicate signatures, so this condition is sufficient, no need
+        // to check for the number of unique signers.
+        require(signatures.length >= threshold, "Threshold not met");
+        bytes32 hashToSign = ECDSA.toEthSignedMessageHash(keccak256(dataToSign));
+        address lastAddress = address(0);
+        uint len = signatures.length;
+        for (uint i = 0; i < len; i++) {
+            address recovered = ECDSA.recover(hashToSign, signatures[i]);
+            require(isOwner[recovered], "Invalid signature");
+            require(
+                recovered > lastAddress,
+                "The addresses must be provided in the ascending order"
+            );
+            lastAddress = recovered;
+        }
+    }
+
+    function updateOwners(address[] memory newOwners) internal {
+        for (uint i = 0; i < owners.length; i++) {
+            delete isOwner[owners[i]];
+        }
+        for (uint i = 0; i < newOwners.length; i++) {
+            isOwner[newOwners[i]] = true;
+        }
+        owners = newOwners;
+    }
+}

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+const Migrations = artifacts.require("Migrations");
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations);
+};

--- a/migrations/2_deploy_multisig.js
+++ b/migrations/2_deploy_multisig.js
@@ -1,0 +1,5 @@
+const Multisig = artifacts.require("Multisig");
+
+module.exports = function(deployer) {
+  deployer.deploy(Multisig, [], 1);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@openzeppelin/contracts": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.4.0.tgz",
+      "integrity": "sha512-xeKP59REgow5TPBJh3S9BRIm7DDG+Rz3Nt4ANWGUkjk4305DHpyUD5CyMJ6nd2JMmZuFyx4mjvvlCtSJLRnN6w=="
+    },
     "@openzeppelin/contracts-ethereum-package": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@openzeppelin/contracts": "^2.4.0",
     "@openzeppelin/contracts-ethereum-package": "^2.4.0",
     "@openzeppelin/upgrades": "^2.6.0"
   }

--- a/test/Multisig.js
+++ b/test/Multisig.js
@@ -1,0 +1,243 @@
+const Eth = require('web3-eth')
+const Utils = require('web3-utils')
+const Multisig = artifacts.require('Multisig')
+const Consumer = artifacts.require('Consumer')
+const {
+    ignoreRevert, assertRevert, fixSignature, expectConsumerStorage
+} = require('./helpers')
+
+
+const eth = new Eth(Eth.givenProvider)
+
+const caseInsensitiveCompare = (lhs, rhs) => {
+    return lhs.localeCompare(rhs, 'en', {sensitivity: 'base'})
+}
+
+const msigCall = async ({msig, value, targetContract, data, nonce, signers}, rewrites) => {
+    const hashToSign = Utils.soliditySha3(
+        {type: 'uint8', value: '0x19'},
+        {type: 'uint8', value: '0x00'},
+        {type: 'address', value: rewrites.sigAddress || msig.address},
+        {type: 'address', value: rewrites.sigTargetContract || targetContract},
+        {type: 'uint256', value: rewrites.sigValue || value},
+        {type: 'bytes', value: rewrites.sigData || data},
+        {type: 'uint', value: rewrites.sigNonce || nonce}
+    )
+
+    let signatures = await Promise.all(
+        [...signers]
+            .sort(caseInsensitiveCompare)
+            .map(async addr => {
+                return fixSignature(await eth.sign(hashToSign, addr))
+            })
+    )
+    if (rewrites.corruptSignatures) {
+        signatures = rewrites.corruptSignatures(signatures)
+    }
+
+
+    const execParams = [
+        rewrites.txTargetContract || targetContract,
+        rewrites.txValue || value,
+        rewrites.txData || data,
+        signatures
+    ]
+
+    const defaultGas = 1000000
+    // We still want failed transactions to be recorded on chain for
+    // debug purposes, so we ignore any failures that may occur at
+    // this stage and just substitute the default value.
+    const gas = await ignoreRevert(
+        msig.execute.estimateGas(
+            ...execParams, { from: signers[0] }
+        )
+    ) || defaultGas
+    await msig.execute.sendTransaction(
+        ...execParams, { from: signers[0], gas: gas }
+    )
+}
+
+const msigRotateKeys = ({msig, newOwners, newThreshold, nonce, signers}, rewrites) => {
+    const hashToSign = Utils.soliditySha3(
+        {type: 'uint8', value: '0x19'},
+        {type: 'uint8', value: '0x00'},
+        {type: 'address', value: rewrites.sigAddress || msig.address},
+        {type: 'address[]', value: rewrites.sigNewOwners || newOwners},
+        {type: 'uint', value: rewrites.sigNewThreshold || newThreshold},
+        {type: 'uint', value: rewrites.sigNonce || nonce}
+    )
+}
+
+const splitAccounts = accounts => {
+    assert(
+        accounts.length >= 9,
+        "Running multisig tests require at least 9 active accounts"
+    )
+
+    const a = accounts.slice(0, 9).sort(caseInsensitiveCompare)
+    const evil1 = a.splice(0, 1)[0]  // start
+    const evil2 = a.splice(3, 1)[0]  // owners middle
+    const evil3 = a.splice(-1, 1)[0] // end
+    return {
+        evils: [evil1, evil2, evil3],
+        owners: a.slice(0, 5),
+        newOwners: a.slice(1),
+    }
+}
+
+contract('Multisig', accounts => {
+    // We want to test evil keys at different positions but since the signers
+    // are sorted before calling multisig, we need evil keys to be in different
+    // positions _lexicographically_. We first fetch the evil keys, and then
+    // use the remaining ones as multisig owners/newOwners.
+    const { evils, owners, newOwners } = splitAccounts(accounts)
+
+    beforeEach(async () => {
+        this.msig = await Multisig.new(owners, 2)
+        this.consumer = await Consumer.new()
+    })
+
+    describe('rotateKeys', async () => {
+        const callRotateKeysWithMultisig = async (msig, signers, newOwners, rewrites) => {
+
+        }
+    })
+
+    describe('call', async () => {
+        const callConsumerWithMultisig = async (msig, consumer, signers, rewrites) => {
+            const consumerParam =
+                consumer.contract.methods.updateData(
+                    '0x0123456789abcdeffedcba', '0x2019deadbeef2020',
+                    123456789, "Hello world"
+                ).encodeABI()
+
+            const params = {
+                msig: msig,
+                value: '0',
+                targetContract: consumer.address,
+                data: consumerParam,
+                nonce: 0,
+                signers: signers
+            }
+            return await msigCall(params, rewrites || {})
+        }
+
+        it('makes a requested call if everything is correct', async () => {
+            await callConsumerWithMultisig(this.msig, this.consumer, owners)
+            await expectConsumerStorage(
+                this.consumer,
+                {
+                    lastFixedBytes: '0x0123456789abcdeffedcba',
+                    lastVarBytes: '0x2019deadbeef2020',
+                    lastUint: 123456789,
+                    lastString: "Hello world"
+                }
+            )
+        })
+
+        it('fails if nonce is incorrect', async () => {
+            await assertRevert(
+                callConsumerWithMultisig(
+                    this.msig, this.consumer, owners,
+                    { sigNonce: 1 }
+                ),
+                "Invalid signature"
+            )
+        })
+
+        it('fails if target contract is incorrect (in signature)', async () => {
+            await assertRevert(
+                callConsumerWithMultisig(
+                    this.msig, this.consumer, owners,
+                    { sigTargetContract: evils[0] }
+                ),
+                "Invalid signature"
+            )
+        })
+
+        it('fails if signed by a non-owner (start pos)', async () => {
+            const signers = [evils[0], ...owners.slice(1)]
+            await assertRevert(
+                callConsumerWithMultisig(this.msig, this.consumer, signers),
+                "Invalid signature"
+            )
+        })
+
+        it('fails if signed by a non-owner (middle pos)', async () => {
+            const signers = [evils[1], ...owners.slice(1)]
+            await assertRevert(
+                callConsumerWithMultisig(this.msig, this.consumer, signers),
+                "Invalid signature"
+            )
+        })
+
+        it('fails if signed by a non-owner (end pos)', async () => {
+            const signers = [evils[2], ...owners.slice(1)]
+            await assertRevert(
+                callConsumerWithMultisig(this.msig, this.consumer, signers),
+                "Invalid signature"
+            )
+        })
+
+        it('fails if signature is corrupted (start pos)', async () => {
+            const corruptFirst = signatures => {
+                return ['0x00', ...signatures.slice(1)]
+            }
+            await assertRevert(
+                callConsumerWithMultisig(
+                    this.msig, this.consumer, owners,
+                    { corruptSignatures: corruptFirst }
+                ),
+                "Invalid signature"
+            )
+        })
+
+        it('fails if signature is corrupted (middle pos)', async () => {
+            const corruptMiddle = signatures => {
+                const middle = signatures.length / 2
+                const start = signatures.slice(0, middle)
+                const rest = signatures.slice(middle + 1)
+                return [...start, '0x00', ...rest]
+            }
+            await assertRevert(
+                callConsumerWithMultisig(
+                    this.msig, this.consumer, owners,
+                    { corruptSignatures: corruptMiddle }
+                ),
+                "Invalid signature"
+            )
+        })
+
+        it('fails if signature is corrupted (end pos)', async () => {
+            const corruptLast = signatures => {
+                return [...signatures.slice(0, -1), '0x00']
+            }
+            await assertRevert(
+                callConsumerWithMultisig(
+                    this.msig, this.consumer, owners,
+                    { corruptSignatures: corruptLast }
+                ),
+                "Invalid signature"
+            )
+        })
+    })
+
+    describe('isOwner', async () => {
+        it('should return true for all owners', async () => {
+            for (let owner of owners) {
+                assert.equal(
+                    await this.msig.isOwner.call(owner), true,
+                    `Multisig owner ${owner} is non-owner`
+                )
+            }
+        })
+        it('should return false for non-owners', async () => {
+            for (let evil of evils) {
+                assert.equal(
+                    await this.msig.isOwner.call(evil), false,
+                    `Multisig non-owner ${evil} is owner`
+                )
+            }
+        })
+    })
+})

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,59 @@
+const isRevert = error => {
+    const REVERT_MSGS = [
+        'Returned error: VM Exception while processing transaction: revert',
+        'Returned error: execution error: revert',
+    ]
+    return REVERT_MSGS.some(msg => error.message.startsWith(msg))
+}
+
+module.exports = {
+    isRevert: isRevert,
+    ignoreRevert: async promise => {
+        try {
+            return await promise
+        } catch (error) {
+            if (!isRevert(error)) {
+                throw error
+            }
+        }
+    },
+    assertRevert: async (promise, expectedReason) => {
+        try {
+            await promise
+        } catch (error) {
+            assert(
+                isRevert(error),
+                `Expected "revert", got ${error} instead`
+            )
+            assert.equal(
+                error.reason, expectedReason,
+                "The transaction failed with unexpected reason"
+            )
+
+            return
+        }
+        assert.fail('Expected revert not received')
+    },
+
+    fixSignature: signature => {
+        // in geth its always 27/28, in ganache its 0/1. Change to 27/28 to prevent
+        // signature malleability if version is 0/1
+        // see https://github.com/ethereum/go-ethereum/blob/v1.8.23/internal/ethapi/api.go#L465
+        let v = parseInt(signature.slice(130, 132), 16);
+        if (v < 27) {
+          v += 27;
+        }
+        const vHex = v.toString(16);
+        return signature.slice(0, 130) + vHex;
+    },
+
+    expectConsumerStorage: async (consumer, fields) => {
+        for (const [fieldName, expectedValue] of Object.entries(fields)) {
+            const actualValue = await consumer.contract.methods[fieldName]().call()
+            assert.equal(
+                actualValue, expectedValue,
+                `Field ${fieldName} has unexpected value`
+            )
+        }
+    },
+}


### PR DESCRIPTION
 Problem: According to the requirements, Blend token must be controlled by a multisig quorum. The existing multisig implementations I have reviewed use on-chain order book. Having an on-chain book introduces additional complexity to the contract. Moreover, it discloses valuable information about the upcoming yet unconfirmed transactions that may influence the intrinsic token value on external exchanges.               
                                                                                                                                                                                                     Solution: Add a multisig contract with off-chain signing flow. Provide tests for `execute` operation.